### PR TITLE
Update source/_posts/2011-09-20-nomethoderror-in-rails-3.markdown

### DIFF
--- a/source/_posts/2011-09-20-nomethoderror-in-rails-3.markdown
+++ b/source/_posts/2011-09-20-nomethoderror-in-rails-3.markdown
@@ -25,6 +25,6 @@ The real reason this occurs is either because the Object itself is Nil (and you 
 
 2. If you see the correct class type in the error then you’ve just failed to declare that method or perhaps mistyped its name. Verify that the method exists in the class and that you don’t have any spelling errors :)
 
-You should follow me on Twitter [here.](http://twitter.com/rob_dodson)
+You should follow me on Twitter [here](http://twitter.com/rob_dodson).
 
 ### Lijia is the bestest girlfriend of the universe since the beginning of time


### PR DESCRIPTION
Moved period outside of anchor in second-to-last sentence.
